### PR TITLE
59 - Change platform field datatype in schema.

### DIFF
--- a/architecture/database/README.md
+++ b/architecture/database/README.md
@@ -1,14 +1,14 @@
 ## Database
 
-## Overview
+### Overview
 The database containing train data is a PostgreSQL database hosted on AWS RDS. This directory contains files to connect to the database and populate it with the relevant data tables.
 
-## Explanation
+### Explanation
 - `schema.sql` resets the database. All tables are dropped if they exist and then re-created to populate the database according to the project ERD.
 - `connect.sh` is a shell script which connects you to the database using the correct credentials.
 - `apply_schema.sh` is a shell script which connects you to the database and runs the schema file to populate the database.
 
-## Setup and Installation
+### Setup and Installation
 1. Create a `.env` file with the following credentials:
 - `DB_USER`
 - `DB_PASSWORD`
@@ -17,6 +17,6 @@ The database containing train data is a PostgreSQL database hosted on AWS RDS. T
 - `DB_PORT`=5432
 
 
-## Usage
+### Usage
 1. Run the `apply_schema.sh` shell script to populate the database.
 - `bash apply_schema.sh`

--- a/architecture/database/apply_schema.sh
+++ b/architecture/database/apply_schema.sh
@@ -1,4 +1,4 @@
 # Connects to the database and runs schema.sql file.
 source .env
-export PGPASSWORD = $DB_PASSWORD
+export PGPASSWORD=$DB_PASSWORD
 psql -h $DB_HOST -U $DB_USER -d $DB_NAME -p $DB_PORT -c "schema.sql"

--- a/architecture/database/apply_schema.sh
+++ b/architecture/database/apply_schema.sh
@@ -1,4 +1,4 @@
 # Connects to the database and runs schema.sql file.
 source .env
 export PGPASSWORD=$DB_PASSWORD
-psql -h $DB_HOST -U $DB_USER -d $DB_NAME -p $DB_PORT -c "schema.sql"
+psql -h $DB_HOST -U $DB_USER -d $DB_NAME -p $DB_PORT -c "\i schema.sql"

--- a/architecture/database/connect.sh
+++ b/architecture/database/connect.sh
@@ -1,4 +1,4 @@
 # Connects to the database if .env is correctly set up.
 source .env
-export PGPASSWORD = $DB_PASSWORD
+export PGPASSWORD=$DB_PASSWORD
 psql -h $DB_HOST -U $DB_USER -d $DB_NAME -p $DB_PORT

--- a/architecture/database/schema.sql
+++ b/architecture/database/schema.sql
@@ -50,7 +50,7 @@ CREATE TABLE train_stop (
     actual_arr_time TIME,
     scheduled_dep_time TIME,
     actual_dep_time TIME,
-    platform SMALLINT NOT NULL,
+    platform VARCHAR(3) NOT NULL,
     platform_changed BOOLEAN NOT NULL,
     PRIMARY KEY (train_stop_id),
     FOREIGN KEY (station_id) REFERENCES station(station_id),


### PR DESCRIPTION
## Body:
Changed the platform datatype to `VARCHAR(3)` from `SMALLINT` after we found non-numerical platforms (e.g. A) in the data. Also fixed some small issues with formatting in the shell scripts and README.

## Changes include (or breakdown of change):
- Changed datatype for `platform` field in `train_stop` table to `VARCHAR(3)` in `/architecture/database/schema.sh`.
- Removed spaces in `export PGPASSWORD=$DB_PASSWORD` in `/architecture/database/connect.sh` and `/architecture/database/apply_schema.sh`.
- Changed heading size in `/architecture/database/README.md` to be consistent with those in the `/pipeline` directory.
- Added `\i` to `psql` command in `/architecture/database/apply_schema.sh` script to fix syntax error.

Closes: #59.
