### PR TITLE
30 - Add extract script for summary reports.

### DIFF
--- a/report/README.md
+++ b/report/README.md
@@ -5,7 +5,7 @@ This directory contains the scripts for an AWS Lambda which creates PDF summary 
 
 ### Explanation
 `extract_report_data.py` - Extracts data from the RDS for each station from the previous day.   
-`test_extract_incidents.py` - Tests for the extract script.   
+`test_extract_report_data.py` - Tests for the extract script.   
 `conftest.py` - Contains fixtures for the tests.   
 
 ### Setup and Installation

--- a/report/README.md
+++ b/report/README.md
@@ -1,41 +1,28 @@
-Directory name
+## Report
 
-Overview
-[Brief summary of the purpose of the directory]
+### Overview
+This directory contains the scripts for an AWS Lambda which creates PDF summary reports of a train station's performance (delays, cancellations) from the previous day's data in the RDS database.
 
-Explanation
-[Sentence about the purpose of each file in directory]
+### Explanation
+`extract_report_data.py` - Extracts data from the RDS for each station from the previous day.   
+`test_extract_incidents.py` - Tests for the extract script.   
+`conftest.py` - Contains fixtures for the tests.   
 
-Setup and Installation
-[Any necessary steps for setting up the directory + installing dependencies]
-1.
-2.
-3.
-
-Usage
-[Instructions for using files in the directory]
-1.
-2.
-3.
-
-
-## Example 
-Railway Pipeline
-
-Overview
-An ETL pipeline which extracts data from the National Rail API, transforms it to a clean, consistent format and loads it to AWS RDS Database.
-
-Explanation
-- `pipeline.py` runs the extract, transform and load processes to take data from API to database.
-
-
-Setup and Installation
-1. Create and activate a new virtual environment 
+### Setup and Installation
+1. Create and activate a new virtual environment.
 - `python3 -m venv .venv`
 - `source .venv/bin/activate`
 2. Install all dependencies.
 - `pip install -r requirements.txt`
+3. Ensure the following environment variables are stored locally in a `.env` file:
+- `DB_USER`
+- `DB_PASSWORD`
+- `DB_HOST`
+- `DB_NAME`
+- `DB_PORT`=5432
 
-Usage
-1. Run the `pipeline.py` file to run the data pipeline.
-- `python3 pipeline.py
+### Usage
+1.
+2.
+3.
+

--- a/report/conftest.py
+++ b/report/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for testing report files."""
 
 from pytest import fixture
-from pandas import DataFrame
 
 
 @fixture

--- a/report/conftest.py
+++ b/report/conftest.py
@@ -1,78 +1,88 @@
 """Fixtures for testing report files."""
 
+import datetime
+
 from pytest import fixture
+from psycopg2.extras import RealDictRow
 
 
 @fixture
 def test_valid_past_day_data():
     """List of dictionaries with valid data for get_days_data_per_station function."""
     return [
-        {
-            "train_stop_id": 1,
-            "train_service_id": 1,
-            "scheduled_arr_time": "09:00:00",
-            "actual_arr_time": "09:00:00",
-            "scheduled_dep_time": "09:02:00",
-            "actual_dep_time": "09:03:00",
-            "platform": 2,
-            "platform_changed": False,
-            "station_id": 1,
-            "station_name": "London Paddington",
-            "station_crs": "PAD",
-            "service_uid": "UID123",
-            "train_identity": "U123",
-            "service_date": "2025-06-10",
-            "route_id": 1
-        },
-        {
-            "train_stop_id": 4,
-            "train_service_id": 2,
-            "scheduled_arr_time": "10:00:00",
-            "actual_arr_time": "10:00:00",
-            "scheduled_dep_time": "10:02:00",
-            "actual_dep_time": "10:02:00",
-            "platform": 2,
-            "platform_changed": False,
-            "station_id": 1,
-            "station_name": "London Paddington",
-            "station_crs": "PAD",
-            "service_uid": "UID124",
-            "train_identity": "W123",
-            "service_date": "2025-06-10",
-            "route_id": 1
-        },
-        {
-            "train_stop_id": 7,
-            "train_service_id": 3,
-            "scheduled_arr_time": "11:00:00",
-            "actual_arr_time": "11:02:00",
-            "scheduled_dep_time": "11:02:00",
-            "actual_dep_time": "11:04:00",
-            "platform": 2,
-            "platform_changed": False,
-            "station_id": 1,
-            "station_name": "London Paddington",
-            "station_crs": "PAD",
-            "service_uid": "UID125",
-            "train_identity": "J123",
-            "service_date": "2025-06-10",
-            "route_id": 1
-        },
-        {
-            "train_stop_id": 10,
-            "train_service_id": 4,
-            "scheduled_arr_time": "12:00:00",
-            "actual_arr_time": "12:05:00",
-            "scheduled_dep_time": "12:02:00",
-            "actual_dep_time": "12:07:00",
-            "platform": 2,
-            "platform_changed": False,
-            "station_id": 1,
-            "station_name": "London Paddington",
-            "station_crs": "PAD",
-            "service_uid": "UID126",
-            "train_identity": "K123",
-            "service_date": "2025-06-10",
-            "route_id": 1
-        }
+        RealDictRow({
+            'train_stop_id': 108,
+            'train_service_id': 65,
+            'station_id': 11,
+            'scheduled_arr_time': datetime.time(21, 20),
+            'actual_arr_time': datetime.time(21, 18),
+            'scheduled_dep_time': datetime.time(21, 21),
+            'actual_dep_time': datetime.time(21, 21),
+            'platform': '2',
+            'platform_changed': False,
+            'station_name': 'Didcot Parkway',
+            'station_crs': 'DID',
+            'service_uid': 'G04992',
+            'train_identity': '1L90',
+            'service_date': datetime.date(2025, 6, 14),
+            'route_id': 9,
+            'cancellation_id': 13,
+            'reason': 'a problem with the train'
+        }),
+        RealDictRow({
+            'train_stop_id': 119,
+            'train_service_id': 73,
+            'station_id': 11,
+            'scheduled_arr_time': datetime.time(22, 20),
+            'actual_arr_time': datetime.time(22, 18),
+            'scheduled_dep_time': datetime.time(23, 45),
+            'actual_dep_time': datetime.time(23, 45),
+            'platform': '5',
+            'platform_changed': False,
+            'station_name': 'Didcot Parkway',
+            'station_crs': 'DID',
+            'service_uid': 'G05996',
+            'train_identity': '2P86',
+            'service_date': datetime.date(2025, 6, 14),
+            'route_id': 6,
+            'cancellation_id': None,
+            'reason': None
+        }),
+        RealDictRow({
+            'train_stop_id': 20,
+            'train_service_id': 27,
+            'station_id': 11,
+            'scheduled_arr_time': datetime.time(16, 26),
+            'actual_arr_time': datetime.time(16, 35),
+            'scheduled_dep_time': datetime.time(17, 8),
+            'actual_dep_time': datetime.time(17, 15),
+            'platform': '5', 'platform_changed': False,
+            'station_name': 'Didcot Parkway',
+            'station_crs': 'DID',
+            'service_uid': 'G05985',
+            'train_identity': '2P61',
+            'service_date': datetime.date(2025, 6, 14),
+            'route_id': 6,
+            'cancellation_id': None,
+            'reason': None
+        }),
+        RealDictRow({
+            'train_stop_id': 25,
+            'train_service_id': 29,
+            'station_id': 11,
+            'scheduled_arr_time': datetime.time(17, 20),
+            'actual_arr_time': datetime.time(17, 25),
+            'scheduled_dep_time': datetime.time(18, 38),
+            'actual_dep_time': datetime.time(18, 38),
+            'platform': '5',
+            'platform_changed': False,
+            'station_name': 'Didcot Parkway',
+            'station_crs': 'DID',
+            'service_uid': 'G05988',
+            'train_identity': '2P67',
+            'service_date': datetime.date(2025, 6, 14),
+            'route_id': 6,
+            'cancellation_id': None,
+            'reason': None
+        })
     ]

--- a/report/conftest.py
+++ b/report/conftest.py
@@ -1,0 +1,79 @@
+"""Fixtures for testing report files."""
+
+from pytest import fixture
+from pandas import DataFrame
+
+
+@fixture
+def test_valid_past_day_data():
+    """List of dictionaries with valid data for get_days_data_per_station function."""
+    return [
+        {
+            "train_stop_id": 1,
+            "train_service_id": 1,
+            "scheduled_arr_time": "09:00:00",
+            "actual_arr_time": "09:00:00",
+            "scheduled_dep_time": "09:02:00",
+            "actual_dep_time": "09:03:00",
+            "platform": 2,
+            "platform_changed": False,
+            "station_id": 1,
+            "station_name": "London Paddington",
+            "station_crs": "PAD",
+            "service_uid": "UID123",
+            "train_identity": "U123",
+            "service_date": "2025-06-10",
+            "route_id": 1
+        },
+        {
+            "train_stop_id": 4,
+            "train_service_id": 2,
+            "scheduled_arr_time": "10:00:00",
+            "actual_arr_time": "10:00:00",
+            "scheduled_dep_time": "10:02:00",
+            "actual_dep_time": "10:02:00",
+            "platform": 2,
+            "platform_changed": False,
+            "station_id": 1,
+            "station_name": "London Paddington",
+            "station_crs": "PAD",
+            "service_uid": "UID124",
+            "train_identity": "W123",
+            "service_date": "2025-06-10",
+            "route_id": 1
+        },
+        {
+            "train_stop_id": 7,
+            "train_service_id": 3,
+            "scheduled_arr_time": "11:00:00",
+            "actual_arr_time": "11:02:00",
+            "scheduled_dep_time": "11:02:00",
+            "actual_dep_time": "11:04:00",
+            "platform": 2,
+            "platform_changed": False,
+            "station_id": 1,
+            "station_name": "London Paddington",
+            "station_crs": "PAD",
+            "service_uid": "UID125",
+            "train_identity": "J123",
+            "service_date": "2025-06-10",
+            "route_id": 1
+        },
+        {
+            "train_stop_id": 10,
+            "train_service_id": 4,
+            "scheduled_arr_time": "12:00:00",
+            "actual_arr_time": "12:05:00",
+            "scheduled_dep_time": "12:02:00",
+            "actual_dep_time": "12:07:00",
+            "platform": 2,
+            "platform_changed": False,
+            "station_id": 1,
+            "station_name": "London Paddington",
+            "station_crs": "PAD",
+            "service_uid": "UID126",
+            "train_identity": "K123",
+            "service_date": "2025-06-10",
+            "route_id": 1
+        }
+    ]

--- a/report/extract_report_data.py
+++ b/report/extract_report_data.py
@@ -1,0 +1,91 @@
+"""Script for extracting last 24 hours of data for summary reports."""
+
+from os import environ as ENV
+import logging
+
+from psycopg2 import connect
+from psycopg2.extras import RealDictCursor
+from psycopg2.extensions import connection
+from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
+
+logging.basicConfig(
+    level="WARNING",
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S"
+)
+
+
+def get_db_connection():
+    """Gets a connection to the trains database."""
+
+    conn = connect(
+        user=ENV["DB_USER"],
+        password=ENV["DB_PASSWORD"],
+        host=ENV["DB_HOST"],
+        port=ENV["DB_PORT"],
+        database=ENV["DB_NAME"]
+    )
+    return conn
+
+
+def get_station_id_from_crs(station_crs: str, conn: connection) -> int:
+    """Gets corresponding station ID from database for a given station CRS code."""
+
+    with conn.cursor(cursor_factory=RealDictCursor) as curs:
+
+        curs.execute("SELECT * FROM station WHERE station_crs = %",
+                     station_crs.upper())
+        result = curs.fetchone()
+
+        if result:
+            logging.info(
+                "Successfully retrieved station ID for %s", station_crs)
+            result = result[0]
+        else:
+            logging.warning("No station ID retrieved for %s", station_crs)
+        curs.close()
+
+    return result
+
+
+def get_days_data_per_station(station_crs: str, conn: connection) -> list[dict]:
+    """Get data from the last 24 hours for a given station."""
+
+    station_id = get_station_id_from_crs(station_crs, conn)
+
+    query = """
+            SELECT * FROM train_stop
+            JOIN station AS s
+            USING (station_id)
+            JOIN train_service
+            USING (train_service_id)
+            WHERE s.station_id = %
+            AND service_date = current_date - 1;
+            """
+
+    with conn.cursor(cursor_factory=RealDictCursor) as curs:
+
+        curs.execute(query, (station_id,))
+        result = curs.fetchall()
+
+        if result:
+            logging.info(
+                "Successfully retrieved past day's data for %s", station_crs)
+        else:
+            logging.warning("No past data retrieved for %s", station_crs)
+        curs.close()
+
+    return result
+
+
+if __name__ == "__main__":
+    load_dotenv()
+
+    db_conn = get_db_connection
+
+    stations = ["PAD", "RDG", "DID", "SWI", "CPM", "BTH", "BRI"]
+
+    for station in stations:
+        get_days_data_per_station(station, db_conn)

--- a/report/extract_report_data.py
+++ b/report/extract_report_data.py
@@ -67,6 +67,8 @@ def get_days_data_per_station(station_crs: str, conn: Connection) -> list[dict]:
             USING (station_id)
             JOIN train_service
             USING (train_service_id)
+            LEFT JOIN cancellation
+            USING (train_stop_id)
             WHERE s.station_id = %s
             AND service_date = current_date - 1;
             """
@@ -79,6 +81,7 @@ def get_days_data_per_station(station_crs: str, conn: Connection) -> list[dict]:
         if result:
             logging.info(
                 "Successfully retrieved past day's data for %s", station_crs)
+            result = [dict(row) for row in result]
         else:
             logging.warning("No past data retrieved for %s", station_crs)
         curs.close()

--- a/report/extract_report_data.py
+++ b/report/extract_report_data.py
@@ -41,14 +41,14 @@ def get_station_id_from_crs(station_crs: str, conn: Connection) -> int:
 
     with conn.cursor(cursor_factory=RealDictCursor) as curs:
 
-        curs.execute("SELECT * FROM station WHERE station_crs = %",
-                     station_crs.upper())
+        curs.execute("SELECT * FROM station WHERE station_crs = %s",
+                     (station_crs,))
         result = curs.fetchone()
 
         if result:
             logging.info(
                 "Successfully retrieved station ID for %s", station_crs)
-            result = result[0]
+            result = dict(result)["station_id"]
         else:
             logging.warning("No station ID retrieved for %s", station_crs)
         curs.close()
@@ -67,7 +67,7 @@ def get_days_data_per_station(station_crs: str, conn: Connection) -> list[dict]:
             USING (station_id)
             JOIN train_service
             USING (train_service_id)
-            WHERE s.station_id = %
+            WHERE s.station_id = %s
             AND service_date = current_date - 1;
             """
 

--- a/report/extract_report_data.py
+++ b/report/extract_report_data.py
@@ -5,7 +5,7 @@ import logging
 
 from psycopg2 import connect
 from psycopg2.extras import RealDictCursor
-from psycopg2.extensions import connection
+from psycopg2.extensions import connection as Connection
 from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ logging.basicConfig(
 )
 
 
-def get_db_connection():
+def get_db_connection() -> Connection:
     """Gets a connection to the trains database."""
 
     conn = connect(
@@ -30,7 +30,7 @@ def get_db_connection():
     return conn
 
 
-def get_station_id_from_crs(station_crs: str, conn: connection) -> int:
+def get_station_id_from_crs(station_crs: str, conn: Connection) -> int:
     """Gets corresponding station ID from database for a given station CRS code."""
 
     with conn.cursor(cursor_factory=RealDictCursor) as curs:
@@ -50,7 +50,7 @@ def get_station_id_from_crs(station_crs: str, conn: connection) -> int:
     return result
 
 
-def get_days_data_per_station(station_crs: str, conn: connection) -> list[dict]:
+def get_days_data_per_station(station_crs: str, conn: Connection) -> list[dict]:
     """Get data from the last 24 hours for a given station."""
 
     station_id = get_station_id_from_crs(station_crs, conn)
@@ -83,7 +83,7 @@ def get_days_data_per_station(station_crs: str, conn: connection) -> list[dict]:
 if __name__ == "__main__":
     load_dotenv()
 
-    db_conn = get_db_connection
+    db_conn = get_db_connection()
 
     stations = ["PAD", "RDG", "DID", "SWI", "CPM", "BTH", "BRI"]
 

--- a/report/extract_report_data.py
+++ b/report/extract_report_data.py
@@ -3,7 +3,7 @@
 from os import environ as ENV
 import logging
 
-from psycopg2 import connect
+from psycopg2 import connect, OperationalError
 from psycopg2.extras import RealDictCursor
 from psycopg2.extensions import connection as Connection
 from dotenv import load_dotenv
@@ -20,13 +20,19 @@ logging.basicConfig(
 def get_db_connection() -> Connection:
     """Gets a connection to the trains database."""
 
-    conn = connect(
-        user=ENV["DB_USER"],
-        password=ENV["DB_PASSWORD"],
-        host=ENV["DB_HOST"],
-        port=ENV["DB_PORT"],
-        database=ENV["DB_NAME"]
-    )
+    try:
+        conn = connect(
+            user=ENV["DB_USER"],
+            password=ENV["DB_PASSWORD"],
+            host=ENV["DB_HOST"],
+            port=ENV["DB_PORT"],
+            database=ENV["DB_NAME"]
+        )
+        logging.info("Successfully retrieved database connection.")
+    except OperationalError:
+        logging.error("Failed to get database connection.")
+        raise
+
     return conn
 
 

--- a/report/requirements.txt
+++ b/report/requirements.txt
@@ -1,0 +1,5 @@
+psycopg2
+pandas
+pytest
+pylint
+python-dotenv

--- a/report/test_extract_report_data.py
+++ b/report/test_extract_report_data.py
@@ -1,6 +1,7 @@
 """Testing file for extract script to create summary reports."""
 
 from unittest.mock import MagicMock, patch
+from psycopg2.extras import RealDictRow
 
 from extract_report_data import (get_db_connection, get_days_data_per_station,
                                  get_station_id_from_crs)
@@ -23,7 +24,8 @@ def test_get_db_connection_called_once():
 def test_get_station_id_from_crs_true_with_valid_crs():
     """Tests that get_station_id function returns ID when valid CRS is passed."""
     mock_cursor = MagicMock()
-    mock_cursor.fetchone.return_value = (1, "London Paddington", "PAD")
+    mock_cursor.fetchone.return_value = RealDictRow(
+        {"station_id": 1, "station_name": "London Paddington", "station_crs": "PAD"})
 
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__.return_value = mock_cursor

--- a/report/test_extract_report_data.py
+++ b/report/test_extract_report_data.py
@@ -1,0 +1,73 @@
+"""Testing file for extract script to create summary reports."""
+
+from unittest.mock import MagicMock, patch
+
+from extract_report_data import (get_db_connection, get_days_data_per_station,
+                                 get_station_id_from_crs)
+
+
+def test_get_db_connection_called_once():
+    """Tests that connect gets called correctly in get_db_connection function."""
+    with patch("extract_report_data.connect") as mock_connect, \
+            patch.dict("os.environ", {
+                "DB_USER": "USER",
+                "DB_PASSWORD": "PASSWORD",
+                "DB_HOST": "HOST",
+                "DB_PORT": "PORT",
+                "DB_NAME": "NAME"
+            }):
+        get_db_connection()
+    mock_connect.assert_called_once()
+
+
+def test_get_station_id_from_crs_true_with_valid_crs():
+    """Tests that get_station_id function returns ID when valid CRS is passed."""
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.return_value = (1, "London Paddington", "PAD")
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    assert get_station_id_from_crs("PAD", mock_conn) == 1
+
+
+def test_get_station_id_from_crs_returns_none_crs_not_present():
+    """Tests that get_station_id function returns None when CRS 
+    does not correspond to a station in database."""
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.return_value = None
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    assert not get_station_id_from_crs("PAD", mock_conn)
+
+
+@patch("extract_report_data.get_station_id_from_crs")
+def test_days_data_per_station_returns_correct_data(fake_station_id, test_valid_past_day_data):
+    """Tests that get_station_id function returns None when CRS 
+    does not correspond to a station in database."""
+
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = test_valid_past_day_data
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    assert get_days_data_per_station(
+        "PAD", mock_conn) == test_valid_past_day_data
+
+
+@patch("extract_report_data.get_station_id_from_crs")
+def test_days_data_per_station_returns_false_value_no_results(fake_station_id):
+    """Tests that get_station_id function returns None when CRS 
+    does not correspond to a station in database."""
+
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+
+    assert not get_days_data_per_station(
+        "PAD", mock_conn)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 python-dotenv
 pandas
 pytest-cov
+psycopg2


### PR DESCRIPTION
## Body:
- Added an extract script to get data from the RDS for each station from the previous day.

## Changes include (or breakdown of change):
All in the `/report` directory:
- `extract_report_data.py` - Extracts all data from the previous data for each station in our initial list on the PAD-BRI route.
- `test_extract_report_data.py` - Tests for extract script.
- `conftest.py` - Contains fixtures for tests.
- `README.md` - Updated to reflect changes.

## Additional notes
There will be further updates to the `README.md` for formatting the data for the summary reports and creating the PDF reports.

Closes: #30, #31, #32.
