### PR TITLE
63 - Add master data to schema

### DIFF
--- a/architecture/database/schema.sql
+++ b/architecture/database/schema.sql
@@ -11,7 +11,7 @@ DROP TABLE IF EXISTS station;
 CREATE TABLE station (
     station_id SMALLINT GENERATED ALWAYS AS IDENTITY,
     station_name VARCHAR(50) NOT NULL,
-    station_crs VARCHAR(3) NOT NULL UNIQUE,
+    station_crs VARCHAR(3) NOT NULL,
     PRIMARY KEY (station_id)
 );
 
@@ -88,3 +88,22 @@ CREATE TABLE operator_incident_assignment (
     FOREIGN KEY (incident_id) REFERENCES incident(incident_id),
     FOREIGN KEY (operator_id) REFERENCES operator(operator_id)
 );
+
+INSERT INTO operator VALUES
+    ("Great Western Railway")
+;
+
+INSERT INTO station VALUES
+    ('London Paddington', 'PAD'),
+    ('Bristol Temple Meads', 'BRI'),
+    ('Bath Spa', 'BTH'),
+    ('Swindon', 'SWI'),
+    ('Reading', 'RDG'),
+    ('Chippenham', 'CPM'),
+    ('Paddington Crossrail', 'PAD'),
+    ('Didcot Parkway', 'DID'),
+;
+
+INSERT INTO route
+    (1, 2, 1)
+;


### PR DESCRIPTION
## Body:
Added master data for initial chosen route from London Paddington to Bristol Temple Meads: operator, station stops and route.

## Changes include (or breakdown of change):
- `/architecture/database/schema.sql` - added insert statements to add master data. 
- Also removed `UNIQUE` constraint for `station_crs` field in `station` table since there are related stations which share the same CRS e.g. London Paddington and Paddington Crossrail.

## Additional notes
In our example csv data, there are other services operating on different routes - should I seed the operators, stations and routes that appear in those as well?

Closes: #63.
