### PR TITLE
77 - Add stations environment variable to RTT ETL Lambda

### DIFF
--- a/terraform/resources/README.md
+++ b/terraform/resources/README.md
@@ -19,6 +19,7 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - DB_PORT - Database port.
 - API_USERNAME - RTT API username.
 - API_PASSWORD - RTT API password.
+- STATIONS - Comma separated list of stations to be loaded.
 
 ## Resources provisioned
 

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -122,6 +122,7 @@ resource "aws_lambda_function" "rtt_pipeline_lambda" {
       DB_PORT      = var.DB_PORT
       API_USERNAME = var.API_USERNAME
       API_PASSWORD = var.API_PASSWORD
+      STATIONS     = var.STATIONS
     }
   }
 }

--- a/terraform/resources/variables.tf
+++ b/terraform/resources/variables.tf
@@ -65,3 +65,7 @@ variable "API_PASSWORD" {
 variable "EMAIL" {
   type = string
 }
+
+variable "STATIONS" {
+  type = string
+}


### PR DESCRIPTION

## Body:
Added a `STATIONS` environment variable to the Lambda which runs the RTT API ETL scripts.

Closes: #77.
