### PR TITLE
71 - Transform incidents data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ __pycache__
 
 *.parquet
 
-
+.coverage

--- a/pipelines/incidents-data/README.md
+++ b/pipelines/incidents-data/README.md
@@ -6,9 +6,12 @@ The directory contains the ETL pipeline for the National Rail Incidents API.
 This pipeline extracts train service data from the National Rail Incidents API and processes it into a structured DataFrame format. The data is then transformed before being uploaded to an RDS database hosted on AWS RDS.
 
 ## Explanation
-`extract_incidents.py` - Extract data from the API and turn it into a pandas dataframe.
-`test_extract_incidents.py` - Tests for the extract script.
-`conftest.py` - Contains fixtures for the tests.
+- `extract_incidents.py` - Extract data from the API and turn it into a pandas dataframe.
+- `test_extract_incidents.py` - Tests for the extract script.
+- `transform_incidents.py` - Transform and filter extracted data.
+- `test_transform_incidents.py` - Tests for the transform script.
+- `conftest.py` - Contains fixtures for the tests.
+
 
 ## Setup and Installation
 1. Create and activate a new virtual environment.

--- a/pipelines/incidents-data/README.md
+++ b/pipelines/incidents-data/README.md
@@ -6,7 +6,7 @@ The directory contains the ETL pipeline for the National Rail Incidents API.
 This pipeline extracts train service data from the National Rail Incidents API and processes it into a structured DataFrame format. The data is then transformed before being uploaded to an RDS database hosted on AWS RDS.
 
 ## Explanation
-- `extract_incidents.py` - Extract data from the API and turn it into a pandas dataframe.
+- `extract_incidents.py` - Extract data from the API and turn it into a pandas DataFrame.
 - `test_extract_incidents.py` - Tests for the extract script.
 - `transform_incidents.py` - Transform and filter extracted data.
 - `test_transform_incidents.py` - Tests for the transform script.
@@ -27,4 +27,4 @@ GW_URL = XXX
 ```
 
 ## Usage
-Run `python3 extract_incidents.py` in the command line.
+Run `python3 extract_incidents.py` and `python3 transform_incidents.py` in the command line.

--- a/pipelines/incidents-data/conftest.py
+++ b/pipelines/incidents-data/conftest.py
@@ -1,3 +1,6 @@
+# pylint: skip-file
+"""Fixtures for tests."""
+
 import pytest
 import pandas as pd
 

--- a/pipelines/incidents-data/conftest.py
+++ b/pipelines/incidents-data/conftest.py
@@ -1,8 +1,11 @@
 import pytest
+import pandas as pd
 
 
 @pytest.fixture
 def sample_incident_xml_wrong_line():
+    """An incident example for an incident not on Paddington/Bristol line."""
+
     return """
     <Incidents xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -53,6 +56,8 @@ def sample_incident_xml_wrong_line():
 
 @pytest.fixture
 def sample_incident_xml_right_line():
+    """An incident example for an incident which is on Paddington/Bristol line."""
+
     return """
     <Incidents xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -99,3 +104,33 @@ def sample_incident_xml_right_line():
     </PtIncident>
     </Incidents>
     """
+
+
+@pytest.fixture
+def sample_extracted_data():
+    """A sample DataFrame like what extract() would return."""
+
+    return pd.DataFrame([
+        {
+            "start_time": "2025-06-09T00:00:00.000+01:00",
+            "end_time": "2025-06-13T23:59:00.000+01:00",
+            "description": "<p>The evening engineering work scheduled to take place between Exeter St Davids and Exmouth on Monday to Thursday nights has been cancelled</p>",
+            "incident_number": "001",
+            "version_number": "20250602082813",
+            "is_planned": "true",
+            "info_link": "https://www.nationalrail.co.uk/engineering-works/23-40-exd-exm-20250609/",
+            "summary": "CANCELLED: Engineering work between Exeter St Davids and Exmouth from Monday 9 to Friday 13 June",
+            "routes_affected": "<p>from Exeter St Davids to Exmouth</p>"
+        },
+        {
+            "start_time": "2025-06-09T00:00:00.000+01:00",
+            "end_time": "2025-06-13T23:59:00.000+01:00",
+            "description": "<p>The evening engineering work scheduled to take place between Exeter St Davids and Exmouth on Monday to Thursday nights has been cancelled</p>",
+            "incident_number": "002",
+            "version_number": "20250602082813",
+            "is_planned": "true",
+            "info_link": "https://www.nationalrail.co.uk/engineering-works/23-40-exd-exm-20250609/",
+            "summary": "CANCELLED: Engineering work between Exeter St Davids and Exmouth from Monday 9 to Friday 13 June",
+            "routes_affected": "<p>between London Paddington and Bristol Temple Meads</p>"
+        }
+    ])

--- a/pipelines/incidents-data/extract_incidents.py
+++ b/pipelines/incidents-data/extract_incidents.py
@@ -60,7 +60,7 @@ def extract_relevant_data(namespace: dict, incident_xml: ET) -> dict:
         "summary": summary,
         "routes_affected": routes_affected
     }
-    logger.info("Incident data: %s", incident_data)
+    logger.info("Extraction for incident finished")
     return incident_data
 
 

--- a/pipelines/incidents-data/test_extract_incidents.py
+++ b/pipelines/incidents-data/test_extract_incidents.py
@@ -1,26 +1,11 @@
-"""Tests for extract.py"""
+"""Tests for extract_incidents.py"""
 
 from unittest.mock import Mock, patch
 import xml.etree.ElementTree as ET
 
-import pytest
-
-from extract_incidents import (is_paddington_to_bristol,
-                               extract_relevant_data, parse_xml, get_incident_data)
-
-# Test is_paddington_to_bristol
-
-
-@pytest.mark.parametrize("text,expected", [
-    ("between London Paddington and Bristol Temple Meads", True),
-    ("Between London Paddington and Reading / Bristol Temple Meads / Cheltenham", True),
-    ("between Reading and Bristol Temple Meads", False),
-    ("Paddington to Bristol", False),
-    ("from london paddington to bristol temple meads", True)
-])
-def test_is_paddington_to_bristol_valid_input(text, expected):
-    """Test that it correctly validates a paddington -> bristol line."""
-    assert is_paddington_to_bristol(text) == expected
+from extract_incidents import (extract_relevant_data,
+                               parse_xml,
+                               get_incident_data)
 
 
 # Test extract_relevant_data
@@ -45,24 +30,16 @@ def test_extract_relevant_data(sample_incident_xml_wrong_line):
         "version_number": "20250602082813",
         "is_planned": "true",
         "info_link": "https://www.nationalrail.co.uk/engineering-works/23-40-exd-exm-20250609/",
-        "summary": "CANCELLED: Engineering work between Exeter St Davids and Exmouth from Monday 9 to Friday 13 June"
+        "summary": "CANCELLED: Engineering work between Exeter St Davids and Exmouth from Monday 9 to Friday 13 June",
+        "routes_affected": "<p>from Exeter St Davids to Exmouth</p>"
     }
 
 
 # Test parse_xml
 
 
-def test_parse_xml_wrong_line(sample_incident_xml_wrong_line):
-    """Test that for an incident not on paddington -> bristol line, it is skipped over."""
-    mock_response = Mock()
-    mock_response.text = sample_incident_xml_wrong_line
-    result = parse_xml(mock_response)
-
-    assert not result
-
-
-def test_parse_xml_right_line(sample_incident_xml_right_line):
-    """Test that for an incident on paddington -> bristol line, it is in results."""
+def test_parse_xml_valid_xml_input(sample_incident_xml_right_line):
+    """Test that for an incident xml, it is in results."""
     mock_response = Mock()
     mock_response.text = sample_incident_xml_right_line
     result = parse_xml(mock_response)

--- a/pipelines/incidents-data/test_transform_incidents.py
+++ b/pipelines/incidents-data/test_transform_incidents.py
@@ -1,0 +1,19 @@
+"""Tests for extract.py"""
+
+import pytest
+
+from transform_incidents import (is_paddington_to_bristol)
+
+# Test is_paddington_to_bristol
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("between London Paddington and Bristol Temple Meads", True),
+    ("Between London Paddington and Reading / Bristol Temple Meads / Cheltenham", True),
+    ("between Reading and Bristol Temple Meads", False),
+    ("Paddington to Bristol", False),
+    ("from london paddington to bristol temple meads", True)
+])
+def test_is_paddington_to_bristol_valid_input(text, expected):
+    """Test that it correctly validates a paddington -> bristol line."""
+    assert is_paddington_to_bristol(text) == expected

--- a/pipelines/incidents-data/test_transform_incidents.py
+++ b/pipelines/incidents-data/test_transform_incidents.py
@@ -1,8 +1,9 @@
-"""Tests for extract.py"""
+"""Tests for transform_incidents.py"""
 
 import pytest
+import pandas as pd
 
-from transform_incidents import (is_paddington_to_bristol)
+from transform_incidents import (is_paddington_to_bristol, transform)
 
 # Test is_paddington_to_bristol
 

--- a/pipelines/incidents-data/test_transform_incidents.py
+++ b/pipelines/incidents-data/test_transform_incidents.py
@@ -18,3 +18,41 @@ from transform_incidents import (is_paddington_to_bristol, transform)
 def test_is_paddington_to_bristol_valid_input(text, expected):
     """Test that it correctly validates a paddington -> bristol line."""
     assert is_paddington_to_bristol(text) == expected
+
+
+# Test transform
+
+
+def test_transform_filters_correctly(sample_extracted_data):
+    """Test that only Paddington to Bristol incidents are kept."""
+    transformed = transform(sample_extracted_data)
+    assert len(transformed) == 1
+    assert transformed.iloc[0]["incident_number"] == "002"
+
+
+def test_transform_types(sample_extracted_data):
+    """Test that data types are converted properly."""
+    transformed = transform(sample_extracted_data)
+    row = transformed.iloc[0]
+
+    assert pd.api.types.is_datetime64_any_dtype(transformed["start_time"])
+    assert pd.api.types.is_datetime64_any_dtype(transformed["end_time"])
+    assert pd.api.types.is_bool_dtype(transformed["is_planned"])
+
+
+def test_transform_columns(sample_extracted_data):
+    """Test that the transformed DataFrame contains the correct columns."""
+    expected_columns = {
+        "start_time",
+        "end_time",
+        "description",
+        "incident_number",
+        "version_number",
+        "is_planned",
+        "info_link",
+        "summary"
+    }
+
+    transformed = transform(sample_extracted_data)
+    actual_columns = set(transformed.columns)
+    assert actual_columns == expected_columns

--- a/pipelines/incidents-data/test_transform_incidents.py
+++ b/pipelines/incidents-data/test_transform_incidents.py
@@ -33,7 +33,6 @@ def test_transform_filters_correctly(sample_extracted_data):
 def test_transform_types(sample_extracted_data):
     """Test that data types are converted properly."""
     transformed = transform(sample_extracted_data)
-    row = transformed.iloc[0]
 
     assert pd.api.types.is_datetime64_any_dtype(transformed["start_time"])
     assert pd.api.types.is_datetime64_any_dtype(transformed["end_time"])

--- a/pipelines/incidents-data/transform_incidents.py
+++ b/pipelines/incidents-data/transform_incidents.py
@@ -17,9 +17,6 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-ORIGIN = "London Paddington"
-DEST = "Bristol Temple Meads"
-
 
 def is_paddington_to_bristol(text: str) -> bool:
     """Filters for trains between Paddington and Bristol Temple Meads."""
@@ -29,6 +26,8 @@ def is_paddington_to_bristol(text: str) -> bool:
 
 def transform(df: pd.DataFrame) -> pd.DataFrame:
     """Transform the data to be correct data types."""
+    df = df.copy()
+
     logging.debug("Transform started.")
     df["start_time"] = pd.to_datetime(df["start_time"], utc=True)
     df["end_time"] = pd.to_datetime(df["end_time"], utc=True)
@@ -36,6 +35,14 @@ def transform(df: pd.DataFrame) -> pd.DataFrame:
         {"true": True, "false": False}).fillna(False)
 
     logging.debug(df.dtypes)
+
+    df = df[df["routes_affected"].apply(is_paddington_to_bristol)]
+    logger.info(
+        "Found %s incidents between London Paddington and Bristol.", len(df))
+
+    df.drop(columns=['routes_affected'])
+
+    logger.info(df.head())
 
     return df
 

--- a/pipelines/incidents-data/transform_incidents.py
+++ b/pipelines/incidents-data/transform_incidents.py
@@ -1,0 +1,39 @@
+"""A script to transform data from the National Rail Incidents API."""
+
+from os import environ as ENV
+import logging
+
+from dotenv import load_dotenv
+import pandas as pd
+
+from extract_incidents import extract
+
+logging.basicConfig(
+    level="DEBUG",
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S"
+)
+
+logger = logging.getLogger(__name__)
+
+ORIGIN = "London Paddington"
+DEST = "Bristol Temple Meads"
+
+
+def transform(df: pd.DataFrame) -> pd.DataFrame:
+    """Transform the data to be correct data types."""
+    logging.debug("Transform started.")
+    df["start_time"] = pd.to_datetime(df["start_time"], utc=True)
+    df["end_time"] = pd.to_datetime(df["end_time"], utc=True)
+    df["is_planned"] = df["is_planned"].map(
+        {"true": True, "false": False}).fillna(False)
+
+    logging.debug(df.dtypes)
+
+    return df
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    data = extract()
+    transform(data)

--- a/pipelines/incidents-data/transform_incidents.py
+++ b/pipelines/incidents-data/transform_incidents.py
@@ -49,4 +49,4 @@ def transform(df: pd.DataFrame) -> pd.DataFrame:
 if __name__ == "__main__":
     load_dotenv()
     data = extract()
-    transform(data)
+    transformed = transform(data)

--- a/pipelines/incidents-data/transform_incidents.py
+++ b/pipelines/incidents-data/transform_incidents.py
@@ -39,7 +39,7 @@ def transform(df: pd.DataFrame) -> pd.DataFrame:
     logger.info(
         "Found %s incidents between London Paddington and Bristol.", len(df))
 
-    df.drop(columns=['routes_affected'])
+    df = df.drop(columns=['routes_affected'])
 
     logger.info(df.head())
 

--- a/pipelines/incidents-data/transform_incidents.py
+++ b/pipelines/incidents-data/transform_incidents.py
@@ -1,6 +1,5 @@
 """A script to transform data from the National Rail Incidents API."""
 
-from os import environ as ENV
 import logging
 import re
 

--- a/pipelines/incidents-data/transform_incidents.py
+++ b/pipelines/incidents-data/transform_incidents.py
@@ -2,6 +2,7 @@
 
 from os import environ as ENV
 import logging
+import re
 
 from dotenv import load_dotenv
 import pandas as pd
@@ -18,6 +19,12 @@ logger = logging.getLogger(__name__)
 
 ORIGIN = "London Paddington"
 DEST = "Bristol Temple Meads"
+
+
+def is_paddington_to_bristol(text: str) -> bool:
+    """Filters for trains between Paddington and Bristol Temple Meads."""
+    pattern = r'(between|from) London Paddington (and|to) .*Bristol Temple Meads'
+    return re.search(pattern, text, re.IGNORECASE) is not None
 
 
 def transform(df: pd.DataFrame) -> pd.DataFrame:

--- a/pipelines/incidents-data/transform_incidents.py
+++ b/pipelines/incidents-data/transform_incidents.py
@@ -31,7 +31,7 @@ def transform(df: pd.DataFrame) -> pd.DataFrame:
     df["start_time"] = pd.to_datetime(df["start_time"], utc=True)
     df["end_time"] = pd.to_datetime(df["end_time"], utc=True)
     df["is_planned"] = df["is_planned"].map(
-        {"true": True, "false": False}).fillna(False)
+        {"true": True, "false": False}).fillna(False).astype(bool)
 
     logging.debug(df.dtypes)
 


### PR DESCRIPTION
## Body:
Added the transform script for data extracted from the incidents API. Added tests for the transform script.

I moved the route filtering out of extract and into transform since it makes more sense there. 

## Changes include (or breakdown of change):
- Changed `.gitignore` - Added `.coverage` to the git ignore (for pytest --cov)
- Added `transform_incidents.py` - Transforms extracted incidents data.
- Added `test_transform_incidents.py` - Tests transform script.
- Changed `extract_incidents.py` - No longer filters data, instead adds a `routes_afftected` column to the output DataFrame, which is used for filtering in `transform_incidents.py`
- Changed `test_extract_incidents.py` - Took out tests for the route filter, and adjusted other tests to account for the changes.
- Changed `README.md` - Updated for transform script.
- Changed `conftest.py` - Added new sample data for tests.

[OPTIONAL] Additional notes
Added `.coverage` to the git ignore (for pytest --cov).

Closes #71.
Closes #72.
Closes #73.
