### PR TITLE
93 - Update ETL Lambdas for more memory, and logging permissions

### DIFF
--- a/terraform/resources/README.md
+++ b/terraform/resources/README.md
@@ -9,7 +9,6 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - ACCESS_KEY - AWS IAM access key.
 - SECRET_KEY - The corresponding secret key for the above IAM user.
 - ACCOUNT_ID - AWS Account ID.
-- EMAIL - An email to subscribe to SNS topic.
 - VPC_ID - The ID of the VPC to use.
 - SUBNET_ID_X - The ID's of subnets to use.
 - DB_HOST - RDS instance endpoint.
@@ -23,14 +22,6 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - GW_URL - URL for the incidents API (Great Western Railway services only).
 
 ## Resources provisioned
-
-#### SNS Topic:
-- `c17-trains-sns-topic-rtt-pipeline-alerts`
-- For RTT pipeline alerts.
-
-#### SNS Topic:
-- `c17-trains-sns-topic-incidents-pipeline-alerts`
-- For incidents pipeline alerts.
 
 #### Lambda:
 - `c17-trains-lambda-rtt-pipeline`

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -37,14 +37,14 @@ data "aws_ecr_image" "rtt_pipeline_lambda_image_version" {
 
 # ECR Repository and image for incidents pipeline lambda
 
-# data "aws_ecr_repository" "incidents_pipeline_lambda_image_repo" {
-#   name = "c17-trains-ecr-incidents-pipeline"
-# }
+data "aws_ecr_repository" "incidents_pipeline_lambda_image_repo" {
+  name = "c17-trains-ecr-incidents-pipeline"
+}
 
-# data "aws_ecr_image" "incidents_pipeline_lambda_image_version" {
-#   repository_name = data.aws_ecr_repository.incidents_pipeline_lambda_image_repo.name
-#   image_tag       = "latest"
-# }
+data "aws_ecr_image" "incidents_pipeline_lambda_image_version" {
+  repository_name = data.aws_ecr_repository.incidents_pipeline_lambda_image_repo.name
+  image_tag       = "latest"
+}
 
 # LAMBDA
 
@@ -126,27 +126,27 @@ resource "aws_lambda_function" "rtt_pipeline_lambda" {
 
 # Incidents Pipeline Lambda
 
-# resource "aws_lambda_function" "incidents_pipeline_lambda" {
-#   function_name = "c17-trains-lambda-incidents-pipeline"
-#   description   = "Runs the Incidents ETL Pipeline every one hour. Triggered by an EventBridge."
-#   role          = aws_iam_role.pipeline_lambda_role.arn
-#   package_type  = "Image"
-#   image_uri     = data.aws_ecr_image.incidents_pipeline_lambda_image_version.image_uri
-#   timeout       = 240
-#   memory_size   = 512
-#   depends_on    = [aws_iam_role_policy_attachment.pipeline_lambda_role_policy_connection]
+resource "aws_lambda_function" "incidents_pipeline_lambda" {
+  function_name = "c17-trains-lambda-incidents-pipeline"
+  description   = "Runs the Incidents ETL Pipeline every one hour. Triggered by an EventBridge."
+  role          = aws_iam_role.pipeline_lambda_role.arn
+  package_type  = "Image"
+  image_uri     = data.aws_ecr_image.incidents_pipeline_lambda_image_version.image_uri
+  timeout       = 240
+  memory_size   = 512
+  depends_on    = [aws_iam_role_policy_attachment.pipeline_lambda_role_policy_connection]
 
-#   environment {
-#     variables = {
-#       DB_HOST       = var.DB_HOST
-#       DB_NAME       = var.DB_NAME
-#       DB_USER       = var.DB_USER
-#       DB_PASSWORD   = var.DB_PASSWORD
-#       DB_PORT       = var.DB_PORT
-#       INCIDENTS_URL = var.INCIDENTS_URL
-#     }
-#   }
-# }
+  environment {
+    variables = {
+      DB_HOST       = var.DB_HOST
+      DB_NAME       = var.DB_NAME
+      DB_USER       = var.DB_USER
+      DB_PASSWORD   = var.DB_PASSWORD
+      DB_PORT       = var.DB_PORT
+      INCIDENTS_URL = var.INCIDENTS_URL
+    }
+  }
+}
 
 # EVENTBRIDGE
 
@@ -207,18 +207,18 @@ resource "aws_scheduler_schedule" "rtt_pipeline_lambda_schedule" {
 
 # Scheduler for Incidents pipeline lambda
 
-# resource "aws_scheduler_schedule" "incidents_pipeline_lambda_schedule" {
-#   name       = "c17-trains-schedule-incidents-pipeline"
-#   group_name = "default"
+resource "aws_scheduler_schedule" "incidents_pipeline_lambda_schedule" {
+  name       = "c17-trains-schedule-incidents-pipeline"
+  group_name = "default"
 
-#   flexible_time_window {
-#     mode = "OFF"
-#   }
+  flexible_time_window {
+    mode = "OFF"
+  }
 
-#   schedule_expression = "cron(0 * * * ? *)"
+  schedule_expression = "cron(0 * * * ? *)"
 
-#   target {
-#     arn      = aws_lambda_function.incidents_pipeline_lambda.arn
-#     role_arn = aws_iam_role.scheduler_role.arn
-#   }
-# }
+  target {
+    arn      = aws_lambda_function.incidents_pipeline_lambda.arn
+    role_arn = aws_iam_role.scheduler_role.arn
+  }
+}

--- a/terraform/resources/variables.tf
+++ b/terraform/resources/variables.tf
@@ -62,10 +62,6 @@ variable "API_PASSWORD" {
   type = string
 }
 
-variable "EMAIL" {
-  type = string
-}
-
 variable "STATIONS" {
   type = string
 }


### PR DESCRIPTION
## Body:
Updates the lambdas max memory, logging permissions, sns permissions. Also removed the SNS topics from terraform as they will be created as needed using boto3.

## Changes include (or breakdown of change):
- Removed SNS topics from terraform.
- Update README to remove the SNS topics.
- Let lambdas publish to all SNS resources, this can be updated once we know the ARN's for the topics (when created).
- Fixed lambdas logging permissions.
- Updated lamba max memory from 128MB to 512MB.

Closes: #93 
