### PR TITLE
108 - Terraform the relevant resources to host the dashboard. 

### DIFF
--- a/terraform/ECR/README.md
+++ b/terraform/ECR/README.md
@@ -19,6 +19,10 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - `c17-trains-ecr-incidents-pipeline`
 - Hosts the image for the Incidents pipeline lambda to run.
 
+#### ECR Repository:
+- `c17-trains-ecr-dashboard`
+- Hosts the image for the dashboard task definition to run.
+
 ## Provisioning Resources
 
 To provision resources run the following commands:

--- a/terraform/ECR/main.tf
+++ b/terraform/ECR/main.tf
@@ -15,3 +15,9 @@ resource "aws_ecr_repository" "rtt_pipeline_lambda_image_repo" {
 resource "aws_ecr_repository" "incidents_pipeline_lambda_image_repo" {
   name = "c17-trains-ecr-incidents-pipeline"
 }
+
+# ECR Repository for dashboard image
+
+resource "aws_ecr_repository" "dashboard_td_image_repo" {
+  name = "c17-trains-ecr-dashboard"
+}

--- a/terraform/resources/README.md
+++ b/terraform/resources/README.md
@@ -20,6 +20,7 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - API_PASSWORD - RTT API password.
 - STATIONS - Comma separated list of stations to be loaded.
 - INCIDENTS_URL - URL for the incidents API.
+- TOPIC_PREFIX - Prefix for alerts topics.
 
 ## Resources provisioned
 

--- a/terraform/resources/README.md
+++ b/terraform/resources/README.md
@@ -19,9 +19,27 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - API_USERNAME - RTT API username.
 - API_PASSWORD - RTT API password.
 - STATIONS - Comma separated list of stations to be loaded.
-- GW_URL - URL for the incidents API (Great Western Railway services only).
+- INCIDENTS_URL - URL for the incidents API.
 
 ## Resources provisioned
+
+#### S3 Bucket:
+- `c17-trains-bucket-reports`
+- Stores daily summary reports for archival.
+
+#### Security Group:
+- `c17-trains-ecs-sg`
+- A security group for the ECS Service.
+- Allows incoming HTTP traffic on port 8501 from any IP.
+- Allows outgoing traffic on port 5432. 
+
+#### ECS Task Definition:
+- `c17-trains-td-dashboard`
+- Runs a containerized Streamlit dashboard.
+
+#### ECS Fargate Service:
+- `c17-trains-ecs-service-dashboard`
+- Runs the dashboard as a service.
 
 #### Lambda:
 - `c17-trains-lambda-rtt-pipeline`

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -25,8 +25,8 @@ data "aws_subnet" "public_subnet_3" {
 # S3 BUCKET
 
 resource "aws_s3_bucket" "s3_bucket" {
-    bucket = "c17-trains-bucket-reports"
-    force_destroy = true
+  bucket        = "c17-trains-bucket-reports"
+  force_destroy = true
 }
 
 # ECR
@@ -208,6 +208,22 @@ resource "aws_ecs_task_definition" "dashboard_td" {
         {
           name  = "DB_PASSWORD"
           value = var.DB_PASSWORD
+        },
+        {
+          name  = "TOPIC_PREFIX"
+          value = var.TOPIC_PREFIX
+        },
+        {
+          name  = "ACCESS_KEY"
+          value = var.ACCESS_KEY
+        },
+        {
+          name  = "SECRET_ACCESS_KEY"
+          value = var.SECRET_KEY
+        },
+        {
+          name  = "REGION"
+          value = var.REGION
         }
       ]
     }

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -22,6 +22,13 @@ data "aws_subnet" "public_subnet_3" {
   id = var.SUBNET_ID_3
 }
 
+# S3 BUCKET
+
+resource "aws_s3_bucket" "s3_bucket" {
+    bucket = "c17-trains-bucket-reports"
+    force_destroy = true
+}
+
 # ECR
 
 # ECR Repository and image for RTT pipeline lambda

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -80,13 +80,11 @@ resource "aws_security_group" "ecs_sg" {
   vpc_id      = data.aws_vpc.c17_vpc.id
 }
 
-resource "aws_vpc_security_group_egress_rule" "allow_rds_access" {
+resource "aws_vpc_security_group_egress_rule" "allow_all" {
   security_group_id = aws_security_group.ecs_sg.id
   cidr_ipv4         = "0.0.0.0/0"
-  from_port         = 5432
-  to_port           = 5432
-  ip_protocol       = "tcp"
-  description       = "Allow ECS to access RDS."
+  ip_protocol       = "-1"
+  description       = "Allow all outward access."
 }
 
 resource "aws_vpc_security_group_ingress_rule" "allow_http" {

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -399,7 +399,7 @@ resource "aws_scheduler_schedule" "rtt_pipeline_lambda_schedule" {
     mode = "OFF"
   }
 
-  schedule_expression = "cron(*/5 * * * ? *)"
+  schedule_expression = "cron(* * * * ? *)"
 
   target {
     arn      = aws_lambda_function.rtt_pipeline_lambda.arn

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -46,6 +46,45 @@ data "aws_ecr_image" "incidents_pipeline_lambda_image_version" {
   image_tag       = "latest"
 }
 
+# ECR Repository and image for dashboard task definition
+
+data "aws_ecr_repository" "dashboard_td_image_repo" {
+  name = "c17-trains-ecr-dashboard"
+}
+
+data "aws_ecr_image" "dashboard_td_image_version" {
+  repository_name = data.aws_ecr_repository.dashboard_td_image_repo.name
+  image_tag       = "latest"
+}
+
+# ECS
+
+# Security Group
+
+resource "aws_security_group" "ecs_sg" {
+  name        = "c17-trains-ecs-sg"
+  description = "Allow HTTP access to dashboard."
+  vpc_id      = data.aws_vpc.c17_vpc.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_rds_access" {
+  security_group_id = aws_security_group.ecs_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 5432
+  to_port           = 5432
+  ip_protocol       = "tcp"
+  description       = "Allow ECS to access RDS."
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_http" {
+  security_group_id = aws_security_group.ecs_sg.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 8501
+  to_port           = 8501
+  ip_protocol       = "tcp"
+  description       = "Allow HTTP access from anywhere."
+}
+
 # LAMBDA
 
 # Permissions for RTT and incidents pipeline lambda

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -383,7 +383,8 @@ resource "aws_iam_role_policy" "eventbridge_invoke_lambda_policy" {
         Action = "lambda:InvokeFunction"
         Effect = "Allow"
         Resource = [
-          aws_lambda_function.rtt_pipeline_lambda.arn
+          aws_lambda_function.rtt_pipeline_lambda.arn,
+          aws_lambda_function.incidents_pipeline_lambda.arn
         ]
       }
     ]

--- a/terraform/resources/variables.tf
+++ b/terraform/resources/variables.tf
@@ -69,3 +69,7 @@ variable "STATIONS" {
 variable "INCIDENTS_URL" {
   type = string
 }
+
+variable "TOPIC_PREFIX" {
+  type = string
+}


### PR DESCRIPTION
## Body:
Created new resources to host the dashboard on AWS.

## Changes include (or breakdown of change):
- Created ECR repo for dashboard image - `c17-trains-ecr-dashboard`.
- Created S3 bucket for daily report archival - `c17-trains-bucket-reports`.
- Created security group for ECS - `c17-trains-ecs-sg`.
- Created task definition for the dashboard image - `c17-trains-td-dashboard`.
- Created ECS Fargate service to run the task definition - `c17-trains-ecs-service-dashboard`.
- Edited scheduler permissions to allow it to run the incidents pipeline lambda.

Closes: #108 
