### PR TITLE
123 - Terraform resources for reports lambda

### DIFF
--- a/terraform/ECR/README.md
+++ b/terraform/ECR/README.md
@@ -20,6 +20,10 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - Hosts the image for the Incidents pipeline lambda to run.
 
 #### ECR Repository:
+- `c17-trains-ecr-reports`
+- Hosts the image for the Reports lambda to run.
+
+#### ECR Repository:
 - `c17-trains-ecr-dashboard`
 - Hosts the image for the dashboard task definition to run.
 

--- a/terraform/ECR/main.tf
+++ b/terraform/ECR/main.tf
@@ -16,6 +16,12 @@ resource "aws_ecr_repository" "incidents_pipeline_lambda_image_repo" {
   name = "c17-trains-ecr-incidents-pipeline"
 }
 
+# ECR Repository for reports lambda image
+
+resource "aws_ecr_repository" "reports_lambda_image_repo" {
+  name = "c17-trains-ecr-reports"
+}
+
 # ECR Repository for dashboard image
 
 resource "aws_ecr_repository" "dashboard_td_image_repo" {

--- a/terraform/resources/README.md
+++ b/terraform/resources/README.md
@@ -50,13 +50,21 @@ Create a `terraform.tfvars` file locally, and populate it with:
 - `c17-trains-lambda-incidents-pipeline`
 - Runs the incidents ETL pipeline.
 
+#### Lambda:
+- `c17-trains-lambda-reports`
+- Generates daily summary reports.
+
 #### Scheduler:
 - `c17-trains-schedule-rtt-pipeline`
-- Schedules the RTT ETL pipeline lambda to run every 5 minutes.
+- Schedules the RTT ETL pipeline lambda to run every minute.
 
 #### Scheduler:
 - `c17-trains-schedule-incidents-pipeline`
 - Schedules the incidents ETL pipeline lambda to run every 1 hour.
+
+#### Scheduler:
+- `c17-trains-schedule-reports`
+- Schedules the incidents ETL pipeline lambda to run every day at 9am.
 
 ## Provisioning Resources
 

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -347,7 +347,7 @@ data "aws_iam_policy_document" "reports_lambda_role_permissions_policy_doc" {
     actions = [
       "s3:PutObject"
     ]
-    resources = ["arn:aws:s3:${var.REGION}:${var.ACCOUNT_ID}:${aws_s3_bucket.s3_bucket.bucket}/*"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.s3_bucket.bucket}/*"]
   }
 }
 

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -269,7 +269,7 @@ resource "aws_ecs_service" "dashboard_service" {
 
 # LAMBDA
 
-# Permissions for RTT and incidents pipeline lambda
+# Permissions
 
 data "aws_iam_policy_document" "lambda_role_trust_policy_doc" {
   statement {

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -307,7 +307,8 @@ data "aws_iam_policy_document" "pipeline_lambda_role_permissions_policy_doc" {
   statement {
     effect = "Allow"
     actions = [
-      "sns:*"
+      "sns:Publish",
+      "sns:CreateTopic"
     ]
     resources = ["arn:aws:sns:${var.REGION}:${var.ACCOUNT_ID}:*"]
   }
@@ -322,6 +323,15 @@ data "aws_iam_policy_document" "reports_lambda_role_permissions_policy_doc" {
       "logs:PutLogEvents"
     ]
     resources = ["arn:aws:logs:${var.REGION}:${var.ACCOUNT_ID}:*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sns:Publish",
+      "sns:CreateTopic"
+    ]
+    resources = ["arn:aws:sns:${var.REGION}:${var.ACCOUNT_ID}:*"]
   }
 
   statement {

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -328,7 +328,7 @@ data "aws_iam_policy_document" "reports_lambda_role_permissions_policy_doc" {
   statement {
     effect = "Allow"
     actions = [
-      "sns:Publish",
+      "sns:ListSubscriptionsByTopic",
       "sns:CreateTopic"
     ]
     resources = ["arn:aws:sns:${var.REGION}:${var.ACCOUNT_ID}:*"]
@@ -337,7 +337,7 @@ data "aws_iam_policy_document" "reports_lambda_role_permissions_policy_doc" {
   statement {
     effect = "Allow"
     actions = [
-      "ses:*"
+      "ses:SendRawEmail"
     ]
     resources = ["arn:aws:ses:${var.REGION}:${var.ACCOUNT_ID}:*"]
   }

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -129,6 +129,10 @@ data "aws_iam_policy" "s3_full_access" {
   arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
+data "aws_iam_policy" "sns_full_access" {
+  arn = "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
+}
+
 resource "aws_iam_role" "ecs_task_exec_role" {
   name = "c17-trains-ecs-task-exec-role"
 
@@ -164,6 +168,11 @@ resource "aws_iam_role_policy_attachment" "ecs_task_exec_ecr" {
 resource "aws_iam_role_policy_attachment" "ecs_task_exec_s3" {
   role       = aws_iam_role.ecs_task_exec_role.name
   policy_arn = data.aws_iam_policy.s3_full_access.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_exec_sns" {
+  role       = aws_iam_role.ecs_task_exec_role.name
+  policy_arn = data.aws_iam_policy.sns_full_access.arn
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_exec_ecs_role" {

--- a/terraform/resources/main.tf
+++ b/terraform/resources/main.tf
@@ -53,6 +53,17 @@ data "aws_ecr_image" "incidents_pipeline_lambda_image_version" {
   image_tag       = "latest"
 }
 
+# ECR Repository and image for reports lambda
+
+data "aws_ecr_repository" "reports_lambda_image_repo" {
+  name = "c17-trains-ecr-reports"
+}
+
+data "aws_ecr_image" "dashboard_td_image_version" {
+  repository_name = data.aws_ecr_repository.reports_lambda_image_repo.name
+  image_tag       = "latest"
+}
+
 # ECR Repository and image for dashboard task definition
 
 data "aws_ecr_repository" "dashboard_td_image_repo" {


### PR DESCRIPTION

## Body:
Added new resources to deploy the reports lambda, ECR repo for image, lambda, scheduler to run daily at 9am.
## Changes include (or breakdown of change):
- New ECR Repo in `/ECR/main.tf` - `c17-trains-ecr-reports`
- New policy document for the reports lambda (logging/ses/s3)
- New lambda for reports - `c17-trains-lambda-reports`
- New scheduler for reports lambda - `c17-trains-schedule-reports`
- Updated ECS to have s3 access.

Closes: #123 
